### PR TITLE
Fix type-limits warnings, apply changes from libinput.c

### DIFF
--- a/src/libinput_openbsd.c
+++ b/src/libinput_openbsd.c
@@ -2225,7 +2225,7 @@ update_seat_key_count(struct libinput_seat *seat,
 {
 	uint32_t key = keycode_as_uint32_t(keycode);
 
-	assert(key >= 0 && key <= KEY_MAX);
+	assert(key <= KEY_MAX);
 
 	switch (state) {
 	case LIBINPUT_KEY_STATE_PRESSED:
@@ -2247,7 +2247,7 @@ update_seat_button_count(struct libinput_seat *seat,
 			 enum libinput_button_state state)
 {
 	uint32_t button = button_code_as_uint32_t(button_code);
-	assert(button >= 0 && button <= KEY_MAX);
+	assert(button <= KEY_MAX);
 
 	switch (state) {
 	case LIBINPUT_BUTTON_STATE_PRESSED:


### PR DESCRIPTION
To fix warnings:

[58/59] Compiling C object libinput.so.10.13.0.p/src_libinput_openbsd.c.o
In file included from /usr/include/errno.h:42,
                 from ../src/libinput_openbsd.c:27:
../src/libinput_openbsd.c: In function 'update_seat_key_count':
../src/libinput_openbsd.c:2228:20: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
 2228 |         assert(key >= 0 && key <= KEY_MAX);
      |                    ^~
../src/libinput_openbsd.c: In function 'update_seat_button_count':
../src/libinput_openbsd.c:2250:23: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
 2250 |         assert(button >= 0 && button <= KEY_MAX);
      |                       ^~
