### PR TITLE
libopeninput_openbsd.c: Minimize diff to upstream libinput.c

### DIFF
--- a/src/libinput_openbsd.c
+++ b/src/libinput_openbsd.c
@@ -24,30 +24,29 @@
 
 #include "config.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <string.h>
 #include <sys/epoll.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include "input.h"
-#include "libinput.h"
 #include "libinput-log.h"
 #include "libinput-private.h"
-#include "timer.h"
+#include "libinput.h"
 #include "quirks.h"
-
+#include "timer.h"
 #include "wscons.h"
 
 #define require_event_type(li_, type_, retval_, ...)	\
 	if (type_ == LIBINPUT_EVENT_NONE) abort(); \
 	if (!check_event_type(li_, __func__, type_, __VA_ARGS__, -1)) \
-		return retval_; \
+		return retval_;
 
 #define ASSERT_INT_SIZE(type_) \
 	static_assert(sizeof(type_) == sizeof(unsigned int), \
@@ -85,7 +84,7 @@ ASSERT_INT_SIZE(enum libinput_config_dwtp_state);
 static inline const char *
 event_type_to_str(enum libinput_event_type type)
 {
-	switch(type) {
+	switch (type) {
 	CASE_RETURN_STRING(LIBINPUT_EVENT_DEVICE_ADDED);
 	CASE_RETURN_STRING(LIBINPUT_EVENT_DEVICE_REMOVED);
 	CASE_RETURN_STRING(LIBINPUT_EVENT_KEYBOARD_KEY);
@@ -153,7 +152,9 @@ check_event_type(struct libinput *libinput,
 		const char *name = event_type_to_str(type_in);
 		log_bug_client(libinput,
 			       "Invalid event type %s (%d) passed to %s()\n",
-			       name, type_in, function_name);
+			       name,
+			       type_in,
+			       function_name);
 	}
 
 	return rc;
@@ -223,6 +224,10 @@ struct libinput_event_tablet_tool {
 	struct libinput_tablet_tool *tool;
 	enum libinput_tablet_tool_proximity_state proximity_state;
 	enum libinput_tablet_tool_tip_state tip_state;
+	struct {
+		struct input_absinfo x;
+		struct input_absinfo y;
+	} abs;
 };
 
 struct libinput_event_tablet_pad {
@@ -238,6 +243,10 @@ struct libinput_event_tablet_pad {
 		uint32_t code;
 		enum libinput_key_state state;
 	} key;
+	struct {
+		double v120;
+		int number;
+	} dial;
 	struct {
 		enum libinput_tablet_pad_ring_axis_source source;
 		double position;
@@ -261,15 +270,24 @@ LIBINPUT_ATTRIBUTE_PRINTF(3, 0)
 static void
 libinput_default_log_func(struct libinput *libinput,
 			  enum libinput_log_priority priority,
-			  const char *format, va_list args)
+			  const char *format,
+			  va_list args)
 {
 	const char *prefix;
 
-	switch(priority) {
-	case LIBINPUT_LOG_PRIORITY_DEBUG: prefix = "debug"; break;
-	case LIBINPUT_LOG_PRIORITY_INFO: prefix = "info"; break;
-	case LIBINPUT_LOG_PRIORITY_ERROR: prefix = "error"; break;
-	default: prefix="<invalid priority>"; break;
+	switch (priority) {
+	case LIBINPUT_LOG_PRIORITY_DEBUG:
+		prefix = "debug";
+		break;
+	case LIBINPUT_LOG_PRIORITY_INFO:
+		prefix = "info";
+		break;
+	case LIBINPUT_LOG_PRIORITY_ERROR:
+		prefix = "error";
+		break;
+	default:
+		prefix = "<invalid priority>";
+		break;
 	}
 
 	fprintf(stderr, "libinput %s: ", prefix);
@@ -295,7 +313,8 @@ log_msg_va(struct libinput *libinput,
 void
 log_msg(struct libinput *libinput,
 	enum libinput_log_priority priority,
-	const char *format, ...)
+	const char *format,
+	...)
 {
 	va_list args;
 
@@ -308,7 +327,8 @@ void
 log_msg_ratelimit(struct libinput *libinput,
 		  struct ratelimit *ratelimit,
 		  enum libinput_log_priority priority,
-		  const char *format, ...)
+		  const char *format,
+		  ...)
 {
 	va_list args;
 	enum ratelimit_state state;
@@ -343,8 +363,7 @@ libinput_log_get_priority(const struct libinput *libinput)
 }
 
 LIBINPUT_EXPORT void
-libinput_log_set_handler(struct libinput *libinput,
-			 libinput_log_handler log_handler)
+libinput_log_set_handler(struct libinput *libinput, libinput_log_handler log_handler)
 {
 	libinput->log_handler = log_handler;
 }
@@ -353,8 +372,7 @@ static void
 libinput_device_group_destroy(struct libinput_device_group *group);
 
 static void
-libinput_post_event(struct libinput *libinput,
-		    struct libinput_event *event);
+libinput_post_event(struct libinput *libinput, struct libinput_event *event);
 
 LIBINPUT_EXPORT enum libinput_event_type
 libinput_event_get_type(struct libinput_event *event)
@@ -388,7 +406,7 @@ libinput_event_get_pointer_event(struct libinput_event *event)
 			   LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS,
 			   LIBINPUT_EVENT_POINTER_AXIS);
 
-	return (struct libinput_event_pointer *) event;
+	return (struct libinput_event_pointer *)event;
 }
 
 LIBINPUT_EXPORT struct libinput_event_keyboard *
@@ -399,7 +417,7 @@ libinput_event_get_keyboard_event(struct libinput_event *event)
 			   NULL,
 			   LIBINPUT_EVENT_KEYBOARD_KEY);
 
-	return (struct libinput_event_keyboard *) event;
+	return (struct libinput_event_keyboard *)event;
 }
 
 LIBINPUT_EXPORT struct libinput_event_touch *
@@ -413,7 +431,7 @@ libinput_event_get_touch_event(struct libinput_event *event)
 			   LIBINPUT_EVENT_TOUCH_MOTION,
 			   LIBINPUT_EVENT_TOUCH_CANCEL,
 			   LIBINPUT_EVENT_TOUCH_FRAME);
-	return (struct libinput_event_touch *) event;
+	return (struct libinput_event_touch *)event;
 }
 
 LIBINPUT_EXPORT struct libinput_event_gesture *
@@ -431,7 +449,7 @@ libinput_event_get_gesture_event(struct libinput_event *event)
 			   LIBINPUT_EVENT_GESTURE_HOLD_BEGIN,
 			   LIBINPUT_EVENT_GESTURE_HOLD_END);
 
-	return (struct libinput_event_gesture *) event;
+	return (struct libinput_event_gesture *)event;
 }
 
 LIBINPUT_EXPORT struct libinput_event_tablet_tool *
@@ -445,7 +463,7 @@ libinput_event_get_tablet_tool_event(struct libinput_event *event)
 			   LIBINPUT_EVENT_TABLET_TOOL_TIP,
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON);
 
-	return (struct libinput_event_tablet_tool *) event;
+	return (struct libinput_event_tablet_tool *)event;
 }
 
 LIBINPUT_EXPORT struct libinput_event_tablet_pad *
@@ -455,11 +473,12 @@ libinput_event_get_tablet_pad_event(struct libinput_event *event)
 			   event->type,
 			   NULL,
 			   LIBINPUT_EVENT_TABLET_PAD_RING,
+			   LIBINPUT_EVENT_TABLET_PAD_DIAL,
 			   LIBINPUT_EVENT_TABLET_PAD_STRIP,
 			   LIBINPUT_EVENT_TABLET_PAD_BUTTON,
 			   LIBINPUT_EVENT_TABLET_PAD_KEY);
 
-	return (struct libinput_event_tablet_pad *) event;
+	return (struct libinput_event_tablet_pad *)event;
 }
 
 LIBINPUT_EXPORT struct libinput_event_device_notify *
@@ -471,7 +490,7 @@ libinput_event_get_device_notify_event(struct libinput_event *event)
 			   LIBINPUT_EVENT_DEVICE_ADDED,
 			   LIBINPUT_EVENT_DEVICE_REMOVED);
 
-	return (struct libinput_event_device_notify *) event;
+	return (struct libinput_event_device_notify *)event;
 }
 
 LIBINPUT_EXPORT struct libinput_event_switch *
@@ -482,7 +501,7 @@ libinput_event_get_switch_event(struct libinput_event *event)
 			   NULL,
 			   LIBINPUT_EVENT_SWITCH_TOGGLE);
 
-	return (struct libinput_event_switch *) event;
+	return (struct libinput_event_switch *)event;
 }
 
 LIBINPUT_EXPORT uint32_t
@@ -530,8 +549,7 @@ libinput_event_keyboard_get_key_state(struct libinput_event_keyboard *event)
 }
 
 LIBINPUT_EXPORT uint32_t
-libinput_event_keyboard_get_seat_key_count(
-	struct libinput_event_keyboard *event)
+libinput_event_keyboard_get_seat_key_count(struct libinput_event_keyboard *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -599,8 +617,7 @@ libinput_event_pointer_get_dy(struct libinput_event_pointer *event)
 }
 
 LIBINPUT_EXPORT double
-libinput_event_pointer_get_dx_unaccelerated(
-	struct libinput_event_pointer *event)
+libinput_event_pointer_get_dx_unaccelerated(struct libinput_event_pointer *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -612,8 +629,7 @@ libinput_event_pointer_get_dx_unaccelerated(
 }
 
 LIBINPUT_EXPORT double
-libinput_event_pointer_get_dy_unaccelerated(
-	struct libinput_event_pointer *event)
+libinput_event_pointer_get_dy_unaccelerated(struct libinput_event_pointer *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -649,9 +665,8 @@ libinput_event_pointer_get_absolute_y(struct libinput_event_pointer *event)
 }
 
 LIBINPUT_EXPORT double
-libinput_event_pointer_get_absolute_x_transformed(
-	struct libinput_event_pointer *event,
-	uint32_t width)
+libinput_event_pointer_get_absolute_x_transformed(struct libinput_event_pointer *event,
+						  uint32_t width)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -663,9 +678,8 @@ libinput_event_pointer_get_absolute_x_transformed(
 }
 
 LIBINPUT_EXPORT double
-libinput_event_pointer_get_absolute_y_transformed(
-	struct libinput_event_pointer *event,
-	uint32_t height)
+libinput_event_pointer_get_absolute_y_transformed(struct libinput_event_pointer *event,
+						  uint32_t height)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -699,8 +713,7 @@ libinput_event_pointer_get_button_state(struct libinput_event_pointer *event)
 }
 
 LIBINPUT_EXPORT uint32_t
-libinput_event_pointer_get_seat_button_count(
-	struct libinput_event_pointer *event)
+libinput_event_pointer_get_seat_button_count(struct libinput_event_pointer *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1076,8 +1089,7 @@ libinput_event_gesture_get_dy(struct libinput_event_gesture *event)
 }
 
 LIBINPUT_EXPORT double
-libinput_event_gesture_get_dx_unaccelerated(
-	struct libinput_event_gesture *event)
+libinput_event_gesture_get_dx_unaccelerated(struct libinput_event_gesture *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1094,8 +1106,7 @@ libinput_event_gesture_get_dx_unaccelerated(
 }
 
 LIBINPUT_EXPORT double
-libinput_event_gesture_get_dy_unaccelerated(
-	struct libinput_event_gesture *event)
+libinput_event_gesture_get_dy_unaccelerated(struct libinput_event_gesture *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1140,8 +1151,7 @@ libinput_event_gesture_get_angle_delta(struct libinput_event_gesture *event)
 }
 
 LIBINPUT_EXPORT int
-libinput_event_tablet_tool_x_has_changed(
-				struct libinput_event_tablet_tool *event)
+libinput_event_tablet_tool_x_has_changed(struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1151,13 +1161,11 @@ libinput_event_tablet_tool_x_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_X);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_X);
 }
 
 LIBINPUT_EXPORT int
-libinput_event_tablet_tool_y_has_changed(
-				struct libinput_event_tablet_tool *event)
+libinput_event_tablet_tool_y_has_changed(struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1167,13 +1175,12 @@ libinput_event_tablet_tool_y_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_Y);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_Y);
 }
 
 LIBINPUT_EXPORT int
 libinput_event_tablet_tool_pressure_has_changed(
-				struct libinput_event_tablet_tool *event)
+	struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1183,13 +1190,12 @@ libinput_event_tablet_tool_pressure_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_PRESSURE);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_PRESSURE);
 }
 
 LIBINPUT_EXPORT int
 libinput_event_tablet_tool_distance_has_changed(
-				struct libinput_event_tablet_tool *event)
+	struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1199,13 +1205,11 @@ libinput_event_tablet_tool_distance_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_DISTANCE);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_DISTANCE);
 }
 
 LIBINPUT_EXPORT int
-libinput_event_tablet_tool_tilt_x_has_changed(
-				struct libinput_event_tablet_tool *event)
+libinput_event_tablet_tool_tilt_x_has_changed(struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1215,13 +1219,11 @@ libinput_event_tablet_tool_tilt_x_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_TILT_X);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_TILT_X);
 }
 
 LIBINPUT_EXPORT int
-libinput_event_tablet_tool_tilt_y_has_changed(
-				struct libinput_event_tablet_tool *event)
+libinput_event_tablet_tool_tilt_y_has_changed(struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1231,13 +1233,12 @@ libinput_event_tablet_tool_tilt_y_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_TILT_Y);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_TILT_Y);
 }
 
 LIBINPUT_EXPORT int
 libinput_event_tablet_tool_rotation_has_changed(
-				struct libinput_event_tablet_tool *event)
+	struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1247,13 +1248,11 @@ libinput_event_tablet_tool_rotation_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_ROTATION_Z);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_ROTATION_Z);
 }
 
 LIBINPUT_EXPORT int
-libinput_event_tablet_tool_slider_has_changed(
-				struct libinput_event_tablet_tool *event)
+libinput_event_tablet_tool_slider_has_changed(struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1263,13 +1262,12 @@ libinput_event_tablet_tool_slider_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_SLIDER);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_SLIDER);
 }
 
 LIBINPUT_EXPORT int
 libinput_event_tablet_tool_size_major_has_changed(
-				struct libinput_event_tablet_tool *event)
+	struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1279,13 +1277,12 @@ libinput_event_tablet_tool_size_major_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_SIZE_MAJOR);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_SIZE_MAJOR);
 }
 
 LIBINPUT_EXPORT int
 libinput_event_tablet_tool_size_minor_has_changed(
-				struct libinput_event_tablet_tool *event)
+	struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1295,13 +1292,11 @@ libinput_event_tablet_tool_size_minor_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_SIZE_MINOR);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_SIZE_MINOR);
 }
 
 LIBINPUT_EXPORT int
-libinput_event_tablet_tool_wheel_has_changed(
-				struct libinput_event_tablet_tool *event)
+libinput_event_tablet_tool_wheel_has_changed(struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1311,8 +1306,7 @@ libinput_event_tablet_tool_wheel_has_changed(
 			   LIBINPUT_EVENT_TABLET_TOOL_BUTTON,
 			   LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
 
-	return bit_is_set(event->changed_axes,
-			  LIBINPUT_TABLET_TOOL_AXIS_REL_WHEEL);
+	return bit_is_set(event->changed_axes, LIBINPUT_TABLET_TOOL_AXIS_REL_WHEEL);
 }
 
 LIBINPUT_EXPORT double
@@ -1483,7 +1477,7 @@ libinput_event_tablet_tool_get_wheel_delta(struct libinput_event_tablet_tool *ev
 
 LIBINPUT_EXPORT int
 libinput_event_tablet_tool_get_wheel_delta_discrete(
-				      struct libinput_event_tablet_tool *event)
+	struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1498,14 +1492,14 @@ libinput_event_tablet_tool_get_wheel_delta_discrete(
 
 LIBINPUT_EXPORT double
 libinput_event_tablet_tool_get_x_transformed(struct libinput_event_tablet_tool *event,
-					uint32_t width)
+					     uint32_t width)
 {
 	return 0xdeadbeef; // TODO
 }
 
 LIBINPUT_EXPORT double
 libinput_event_tablet_tool_get_y_transformed(struct libinput_event_tablet_tool *event,
-					uint32_t height)
+					     uint32_t height)
 {
 	return 0xdeadbeef; // TODO
 }
@@ -1603,7 +1597,8 @@ libinput_event_tablet_tool_get_button_state(struct libinput_event_tablet_tool *e
 }
 
 LIBINPUT_EXPORT uint32_t
-libinput_event_tablet_tool_get_seat_button_count(struct libinput_event_tablet_tool *event)
+libinput_event_tablet_tool_get_seat_button_count(
+	struct libinput_event_tablet_tool *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
 			   event->base.type,
@@ -1640,55 +1635,47 @@ libinput_tablet_tool_get_serial(struct libinput_tablet_tool *tool)
 LIBINPUT_EXPORT int
 libinput_tablet_tool_has_pressure(struct libinput_tablet_tool *tool)
 {
-	return bit_is_set(tool->axis_caps,
-			  LIBINPUT_TABLET_TOOL_AXIS_PRESSURE);
+	return bit_is_set(tool->axis_caps, LIBINPUT_TABLET_TOOL_AXIS_PRESSURE);
 }
 
 LIBINPUT_EXPORT int
 libinput_tablet_tool_has_distance(struct libinput_tablet_tool *tool)
 {
-	return bit_is_set(tool->axis_caps,
-			  LIBINPUT_TABLET_TOOL_AXIS_DISTANCE);
+	return bit_is_set(tool->axis_caps, LIBINPUT_TABLET_TOOL_AXIS_DISTANCE);
 }
 
 LIBINPUT_EXPORT int
 libinput_tablet_tool_has_tilt(struct libinput_tablet_tool *tool)
 {
-	return bit_is_set(tool->axis_caps,
-			  LIBINPUT_TABLET_TOOL_AXIS_TILT_X);
+	return bit_is_set(tool->axis_caps, LIBINPUT_TABLET_TOOL_AXIS_TILT_X);
 }
 
 LIBINPUT_EXPORT int
 libinput_tablet_tool_has_rotation(struct libinput_tablet_tool *tool)
 {
-	return bit_is_set(tool->axis_caps,
-			  LIBINPUT_TABLET_TOOL_AXIS_ROTATION_Z);
+	return bit_is_set(tool->axis_caps, LIBINPUT_TABLET_TOOL_AXIS_ROTATION_Z);
 }
 
 LIBINPUT_EXPORT int
 libinput_tablet_tool_has_slider(struct libinput_tablet_tool *tool)
 {
-	return bit_is_set(tool->axis_caps,
-			  LIBINPUT_TABLET_TOOL_AXIS_SLIDER);
+	return bit_is_set(tool->axis_caps, LIBINPUT_TABLET_TOOL_AXIS_SLIDER);
 }
 
 LIBINPUT_EXPORT int
 libinput_tablet_tool_has_wheel(struct libinput_tablet_tool *tool)
 {
-	return bit_is_set(tool->axis_caps,
-			  LIBINPUT_TABLET_TOOL_AXIS_REL_WHEEL);
+	return bit_is_set(tool->axis_caps, LIBINPUT_TABLET_TOOL_AXIS_REL_WHEEL);
 }
 
 LIBINPUT_EXPORT int
 libinput_tablet_tool_has_size(struct libinput_tablet_tool *tool)
 {
-	return bit_is_set(tool->axis_caps,
-			  LIBINPUT_TABLET_TOOL_AXIS_SIZE_MAJOR);
+	return bit_is_set(tool->axis_caps, LIBINPUT_TABLET_TOOL_AXIS_SIZE_MAJOR);
 }
 
 LIBINPUT_EXPORT int
-libinput_tablet_tool_has_button(struct libinput_tablet_tool *tool,
-				uint32_t code)
+libinput_tablet_tool_has_button(struct libinput_tablet_tool *tool, uint32_t code)
 {
 	if (NCHARS(code) > sizeof(tool->buttons))
 		return 0;
@@ -1697,8 +1684,7 @@ libinput_tablet_tool_has_button(struct libinput_tablet_tool *tool,
 }
 
 LIBINPUT_EXPORT void
-libinput_tablet_tool_set_user_data(struct libinput_tablet_tool *tool,
-				   void *user_data)
+libinput_tablet_tool_set_user_data(struct libinput_tablet_tool *tool, void *user_data)
 {
 	tool->user_data = user_data;
 }
@@ -1812,8 +1798,7 @@ libinput_add_fd(struct libinput *libinput,
 }
 
 void
-libinput_remove_source(struct libinput *libinput,
-		       struct libinput_source *source)
+libinput_remove_source(struct libinput *libinput, struct libinput_source *source)
 {
 	epoll_ctl(libinput->epoll_fd, EPOLL_CTL_DEL, source->fd, NULL);
 	source->fd = -1;
@@ -1911,22 +1896,18 @@ libinput_unref(struct libinput *libinput)
 	libinput->interface_backend->destroy(libinput);
 
 	while ((event = libinput_get_event(libinput)))
-	       libinput_event_destroy(event);
+		libinput_event_destroy(event);
 
 	free(libinput->events);
 
 	list_for_each_safe(seat, &libinput->seat_list, link) {
-		list_for_each_safe(device,
-				   &seat->devices_list,
-				   link)
+		list_for_each_safe(device, &seat->devices_list, link)
 			libinput_device_destroy(device);
 
 		libinput_seat_destroy(seat);
 	}
 
-	list_for_each_safe(group,
-			   &libinput->device_group_list,
-			   link) {
+	list_for_each_safe(group, &libinput->device_group_list, link) {
 		libinput_device_group_destroy(group);
 	}
 
@@ -1943,7 +1924,8 @@ libinput_unref(struct libinput *libinput)
 }
 
 struct quirks *
-libinput_device_get_quirks(struct libinput_device *device) {
+libinput_device_get_quirks(struct libinput_device *device)
+{
 	return NULL;
 }
 
@@ -1966,20 +1948,21 @@ libinput_event_destroy(struct libinput_event *event)
 	if (event == NULL)
 		return;
 
-	switch(event->type) {
+	switch (event->type) {
 	case LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY:
 	case LIBINPUT_EVENT_TABLET_TOOL_AXIS:
 	case LIBINPUT_EVENT_TABLET_TOOL_TIP:
 	case LIBINPUT_EVENT_TABLET_TOOL_BUTTON:
 		libinput_event_tablet_tool_destroy(
-		   libinput_event_get_tablet_tool_event(event));
+			libinput_event_get_tablet_tool_event(event));
 		break;
 	case LIBINPUT_EVENT_TABLET_PAD_RING:
+	case LIBINPUT_EVENT_TABLET_PAD_DIAL:
 	case LIBINPUT_EVENT_TABLET_PAD_STRIP:
 	case LIBINPUT_EVENT_TABLET_PAD_BUTTON:
 	case LIBINPUT_EVENT_TABLET_PAD_KEY:
 		libinput_event_tablet_pad_destroy(
-		   libinput_event_get_tablet_pad_event(event));
+			libinput_event_get_tablet_pad_event(event));
 		break;
 	default:
 		break;
@@ -1992,12 +1975,9 @@ libinput_event_destroy(struct libinput_event *event)
 }
 
 int
-open_restricted(struct libinput *libinput,
-		const char *path, int flags)
+open_restricted(struct libinput *libinput, const char *path, int flags)
 {
-	return libinput->interface->open_restricted(path,
-						    flags,
-						    libinput->user_data);
+	return libinput->interface->open_restricted(path, flags, libinput->user_data);
 }
 
 void
@@ -2092,8 +2072,7 @@ libinput_seat_get_logical_name(struct libinput_seat *seat)
 }
 
 void
-libinput_device_init(struct libinput_device *device,
-		     struct libinput_seat *seat)
+libinput_device_init(struct libinput_device *device, struct libinput_seat *seat)
 {
 	device->seat = seat;
 	device->refcount = 1;
@@ -2112,7 +2091,7 @@ libinput_device_destroy(struct libinput_device *device)
 {
 	// TODO
 	assert(list_empty(&device->event_listeners));
-	//wscons_device_destroy(evdev_device(device));
+	// wscons_device_destroy(evdev_device(device));
 }
 
 LIBINPUT_EXPORT struct libinput_device *
@@ -2130,7 +2109,7 @@ libinput_device_unref(struct libinput_device *device)
 
 void
 libinput_device_disable_feature(struct libinput_device *device,
-		                enum libinput_feature feature)
+				enum libinput_feature feature)
 {
 	return;
 }
@@ -2183,10 +2162,9 @@ libinput_device_init_event_listener(struct libinput_event_listener *listener)
 void
 libinput_device_add_event_listener(struct libinput_device *device,
 				   struct libinput_event_listener *listener,
-				   void (*notify_func)(
-						uint64_t time,
-						struct libinput_event *event,
-						void *notify_func_data),
+				   void (*notify_func)(uint64_t time,
+						       struct libinput_event *event,
+						       void *notify_func_data),
 				   void *notify_func_data)
 {
 	listener->notify_func = notify_func;
@@ -2310,9 +2288,7 @@ notify_added_device(struct libinput_device *device)
 
 	added_device_event = zalloc(sizeof *added_device_event);
 
-	post_base_event(device,
-			LIBINPUT_EVENT_DEVICE_ADDED,
-			&added_device_event->base);
+	post_base_event(device, LIBINPUT_EVENT_DEVICE_ADDED, &added_device_event->base);
 
 #ifdef __clang_analyzer__
 	/* clang doesn't realize we're not leaking the event here, so
@@ -2340,8 +2316,7 @@ notify_removed_device(struct libinput_device *device)
 }
 
 static inline bool
-device_has_cap(struct libinput_device *device,
-	       enum libinput_device_capability cap)
+device_has_cap(struct libinput_device *device, enum libinput_device_capability cap)
 {
 	const char *capability;
 
@@ -2396,23 +2371,21 @@ keyboard_notify_key(struct libinput_device *device,
 
 	seat_key_count = update_seat_key_count(device->seat, keycode, state);
 
-	*key_event = (struct libinput_event_keyboard) {
+	*key_event = (struct libinput_event_keyboard){
 		.time = time,
 		.key = keycode_as_uint32_t(keycode),
 		.state = state,
 		.seat_key_count = seat_key_count,
 	};
 
-	post_device_event(device, time,
-			  LIBINPUT_EVENT_KEYBOARD_KEY,
-			  &key_event->base);
+	post_device_event(device, time, LIBINPUT_EVENT_KEYBOARD_KEY, &key_event->base);
 }
 
 void
 axis_notify_event(struct libinput_device *device,
-    uint64_t time,
-    const struct normalized_coords *delta,
-    const struct device_float_coords *raw)
+		  uint64_t time,
+		  const struct normalized_coords *delta,
+		  const struct device_float_coords *raw)
 {
 	struct libinput_event_pointer *axis_event;
 	struct wheel_v120 v120 = { 0.0, 0.0 };
@@ -2429,7 +2402,7 @@ axis_notify_event(struct libinput_device *device,
 		v120.y = delta->y * 3.75;
 	}
 
-	*axis_event = (struct libinput_event_pointer) {
+	*axis_event = (struct libinput_event_pointer){
 		.time = time,
 		.delta = *delta,
 		.delta_raw = *raw,
@@ -2440,8 +2413,10 @@ axis_notify_event(struct libinput_device *device,
 		.v120 = v120
 	};
 
-	post_device_event(device, time, LIBINPUT_EVENT_POINTER_SCROLL_WHEEL,
-	    &axis_event->base);
+	post_device_event(device,
+			  time,
+			  LIBINPUT_EVENT_POINTER_SCROLL_WHEEL,
+			  &axis_event->base);
 }
 
 void
@@ -2457,13 +2432,14 @@ pointer_notify_motion(struct libinput_device *device,
 
 	motion_event = zalloc(sizeof *motion_event);
 
-	*motion_event = (struct libinput_event_pointer) {
+	*motion_event = (struct libinput_event_pointer){
 		.time = time,
 		.delta = *delta,
 		.delta_raw = *raw,
 	};
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_POINTER_MOTION,
 			  &motion_event->base);
 }
@@ -2480,12 +2456,13 @@ pointer_notify_motion_absolute(struct libinput_device *device,
 
 	motion_absolute_event = zalloc(sizeof *motion_absolute_event);
 
-	*motion_absolute_event = (struct libinput_event_pointer) {
+	*motion_absolute_event = (struct libinput_event_pointer){
 		.time = time,
 		.absolute = *point,
 	};
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE,
 			  &motion_absolute_event->base);
 }
@@ -2504,31 +2481,30 @@ pointer_notify_button(struct libinput_device *device,
 
 	button_event = zalloc(sizeof *button_event);
 
-	seat_button_count = update_seat_button_count(device->seat,
-						     button,
-						     state);
+	seat_button_count = update_seat_button_count(device->seat, button, state);
 
-	*button_event = (struct libinput_event_pointer) {
+	*button_event = (struct libinput_event_pointer){
 		.time = time,
 		.button = button_code_as_uint32_t(button),
 		.state = state,
 		.seat_button_count = seat_button_count,
 	};
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_POINTER_BUTTON,
 			  &button_event->base);
 }
 
 void
 pointer_notify_axis_finger(struct libinput_device *device,
-			  uint64_t time,
-			  uint32_t axes,
-			  const struct normalized_coords *delta)
+			   uint64_t time,
+			   uint32_t axes,
+			   const struct normalized_coords *delta)
 {
 	struct libinput_event_pointer *axis_event, *axis_event_legacy;
-	const struct discrete_coords zero_discrete = {0};
-	const struct wheel_v120 zero_v120 = {0};
+	const struct discrete_coords zero_discrete = { 0 };
+	const struct wheel_v120 zero_v120 = { 0 };
 
 	if (!device_has_cap(device, LIBINPUT_DEVICE_CAP_POINTER))
 		return;
@@ -2536,7 +2512,7 @@ pointer_notify_axis_finger(struct libinput_device *device,
 	axis_event = zalloc(sizeof *axis_event);
 	axis_event_legacy = zalloc(sizeof *axis_event_legacy);
 
-	*axis_event = (struct libinput_event_pointer) {
+	*axis_event = (struct libinput_event_pointer){
 		.time = time,
 		.delta = *delta,
 		.source = LIBINPUT_POINTER_AXIS_SOURCE_FINGER,
@@ -2546,10 +2522,12 @@ pointer_notify_axis_finger(struct libinput_device *device,
 	};
 	*axis_event_legacy = *axis_event;
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_POINTER_SCROLL_FINGER,
 			  &axis_event->base);
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_POINTER_AXIS,
 			  &axis_event_legacy->base);
 }
@@ -2561,8 +2539,8 @@ pointer_notify_axis_continuous(struct libinput_device *device,
 			       const struct normalized_coords *delta)
 {
 	struct libinput_event_pointer *axis_event, *axis_event_legacy;
-	const struct discrete_coords zero_discrete = {0};
-	const struct wheel_v120 zero_v120 = {0};
+	const struct discrete_coords zero_discrete = { 0 };
+	const struct wheel_v120 zero_v120 = { 0 };
 
 	if (!device_has_cap(device, LIBINPUT_DEVICE_CAP_POINTER))
 		return;
@@ -2570,7 +2548,7 @@ pointer_notify_axis_continuous(struct libinput_device *device,
 	axis_event = zalloc(sizeof *axis_event);
 	axis_event_legacy = zalloc(sizeof *axis_event_legacy);
 
-	*axis_event = (struct libinput_event_pointer) {
+	*axis_event = (struct libinput_event_pointer){
 		.time = time,
 		.delta = *delta,
 		.source = LIBINPUT_POINTER_AXIS_SOURCE_CONTINUOUS,
@@ -2580,10 +2558,12 @@ pointer_notify_axis_continuous(struct libinput_device *device,
 	};
 	*axis_event_legacy = *axis_event;
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS,
 			  &axis_event->base);
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_POINTER_AXIS,
 			  &axis_event_legacy->base);
 }
@@ -2596,14 +2576,14 @@ pointer_notify_axis_legacy_wheel(struct libinput_device *device,
 				 const struct discrete_coords *discrete)
 {
 	struct libinput_event_pointer *axis_event;
-	const struct wheel_v120 zero_v120 = {0};
+	const struct wheel_v120 zero_v120 = { 0 };
 
 	if (!device_has_cap(device, LIBINPUT_DEVICE_CAP_POINTER))
 		return;
 
 	axis_event = zalloc(sizeof *axis_event);
 
-	*axis_event = (struct libinput_event_pointer) {
+	*axis_event = (struct libinput_event_pointer){
 		.time = time,
 		.delta = *delta,
 		.source = LIBINPUT_POINTER_AXIS_SOURCE_WHEEL,
@@ -2612,9 +2592,7 @@ pointer_notify_axis_legacy_wheel(struct libinput_device *device,
 		.v120 = zero_v120,
 	};
 
-	post_device_event(device, time,
-			  LIBINPUT_EVENT_POINTER_AXIS,
-			  &axis_event->base);
+	post_device_event(device, time, LIBINPUT_EVENT_POINTER_AXIS, &axis_event->base);
 }
 
 void
@@ -2631,7 +2609,7 @@ pointer_notify_axis_wheel(struct libinput_device *device,
 
 	axis_event = zalloc(sizeof *axis_event);
 
-	*axis_event = (struct libinput_event_pointer) {
+	*axis_event = (struct libinput_event_pointer){
 		.time = time,
 		.delta = *delta,
 		.source = LIBINPUT_POINTER_AXIS_SOURCE_WHEEL,
@@ -2641,7 +2619,8 @@ pointer_notify_axis_wheel(struct libinput_device *device,
 		.v120 = *v120,
 	};
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_POINTER_SCROLL_WHEEL,
 			  &axis_event->base);
 
@@ -2662,16 +2641,14 @@ touch_notify_touch_down(struct libinput_device *device,
 
 	touch_event = zalloc(sizeof *touch_event);
 
-	*touch_event = (struct libinput_event_touch) {
+	*touch_event = (struct libinput_event_touch){
 		.time = time,
 		.slot = slot,
 		.seat_slot = seat_slot,
 		.point = *point,
 	};
 
-	post_device_event(device, time,
-			  LIBINPUT_EVENT_TOUCH_DOWN,
-			  &touch_event->base);
+	post_device_event(device, time, LIBINPUT_EVENT_TOUCH_DOWN, &touch_event->base);
 }
 
 void
@@ -2688,14 +2665,15 @@ touch_notify_touch_motion(struct libinput_device *device,
 
 	touch_event = zalloc(sizeof *touch_event);
 
-	*touch_event = (struct libinput_event_touch) {
+	*touch_event = (struct libinput_event_touch){
 		.time = time,
 		.slot = slot,
 		.seat_slot = seat_slot,
 		.point = *point,
 	};
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_TOUCH_MOTION,
 			  &touch_event->base);
 }
@@ -2713,15 +2691,13 @@ touch_notify_touch_up(struct libinput_device *device,
 
 	touch_event = zalloc(sizeof *touch_event);
 
-	*touch_event = (struct libinput_event_touch) {
+	*touch_event = (struct libinput_event_touch){
 		.time = time,
 		.slot = slot,
 		.seat_slot = seat_slot,
 	};
 
-	post_device_event(device, time,
-			  LIBINPUT_EVENT_TOUCH_UP,
-			  &touch_event->base);
+	post_device_event(device, time, LIBINPUT_EVENT_TOUCH_UP, &touch_event->base);
 }
 
 void
@@ -2737,20 +2713,20 @@ touch_notify_touch_cancel(struct libinput_device *device,
 
 	touch_event = zalloc(sizeof *touch_event);
 
-	*touch_event = (struct libinput_event_touch) {
+	*touch_event = (struct libinput_event_touch){
 		.time = time,
 		.slot = slot,
 		.seat_slot = seat_slot,
 	};
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_TOUCH_CANCEL,
 			  &touch_event->base);
 }
 
 void
-touch_notify_frame(struct libinput_device *device,
-		   uint64_t time)
+touch_notify_frame(struct libinput_device *device, uint64_t time)
 {
 	struct libinput_event_touch *touch_event;
 
@@ -2759,13 +2735,11 @@ touch_notify_frame(struct libinput_device *device,
 
 	touch_event = zalloc(sizeof *touch_event);
 
-	*touch_event = (struct libinput_event_touch) {
+	*touch_event = (struct libinput_event_touch){
 		.time = time,
 	};
 
-	post_device_event(device, time,
-			  LIBINPUT_EVENT_TOUCH_FRAME,
-			  &touch_event->base);
+	post_device_event(device, time, LIBINPUT_EVENT_TOUCH_FRAME, &touch_event->base);
 }
 
 void
@@ -2782,7 +2756,7 @@ tablet_notify_axis(struct libinput_device *device,
 
 	axis_event = zalloc(sizeof *axis_event);
 
-	*axis_event = (struct libinput_event_tablet_tool) {
+	*axis_event = (struct libinput_event_tablet_tool){
 		.time = time,
 		.tool = libinput_tablet_tool_ref(tool),
 		.proximity_state = LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN,
@@ -2814,7 +2788,7 @@ tablet_notify_proximity(struct libinput_device *device,
 
 	proximity_event = zalloc(sizeof *proximity_event);
 
-	*proximity_event = (struct libinput_event_tablet_tool) {
+	*proximity_event = (struct libinput_event_tablet_tool){
 		.time = time,
 		.tool = libinput_tablet_tool_ref(tool),
 		.tip_state = LIBINPUT_TABLET_TOOL_TIP_UP,
@@ -2845,16 +2819,14 @@ tablet_notify_tip(struct libinput_device *device,
 
 	tip_event = zalloc(sizeof *tip_event);
 
-	*tip_event = (struct libinput_event_tablet_tool) {
+	*tip_event = (struct libinput_event_tablet_tool){
 		.time = time,
 		.tool = libinput_tablet_tool_ref(tool),
 		.tip_state = tip_state,
 		.proximity_state = LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN,
 		.axes = *axes,
 	};
-	memcpy(tip_event->changed_axes,
-	       changed_axes,
-	       sizeof(tip_event->changed_axes));
+	memcpy(tip_event->changed_axes, changed_axes, sizeof(tip_event->changed_axes));
 
 	post_device_event(device,
 			  time,
@@ -2868,7 +2840,7 @@ tablet_notify_button(struct libinput_device *device,
 		     struct libinput_tablet_tool *tool,
 		     enum libinput_tablet_tool_tip_state tip_state,
 		     const struct tablet_axes *axes,
-		     button_code_t button_code,
+		     button_code_t button,
 		     enum libinput_button_state state,
 		     const struct input_absinfo *x,
 		     const struct input_absinfo *y)
@@ -2878,14 +2850,12 @@ tablet_notify_button(struct libinput_device *device,
 
 	button_event = zalloc(sizeof *button_event);
 
-	seat_button_count = update_seat_button_count(device->seat,
-						     button_code,
-						     state);
+	seat_button_count = update_seat_button_count(device->seat, button, state);
 
-	*button_event = (struct libinput_event_tablet_tool) {
+	*button_event = (struct libinput_event_tablet_tool){
 		.time = time,
 		.tool = libinput_tablet_tool_ref(tool),
-		.button = button_code_as_uint32_t(button_code),
+		.button = button_code_as_uint32_t(button),
 		.state = state,
 		.seat_button_count = seat_button_count,
 		.proximity_state = LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN,
@@ -2902,7 +2872,7 @@ tablet_notify_button(struct libinput_device *device,
 void
 tablet_pad_notify_button(struct libinput_device *device,
 			 uint64_t time,
-			 pad_button_t pad_button,
+			 pad_button_t button,
 			 enum libinput_button_state state,
 			 struct libinput_tablet_pad_mode_group *group)
 {
@@ -2913,9 +2883,9 @@ tablet_pad_notify_button(struct libinput_device *device,
 
 	mode = libinput_tablet_pad_mode_group_get_mode(group);
 
-	*button_event = (struct libinput_event_tablet_pad) {
+	*button_event = (struct libinput_event_tablet_pad){
 		.time = time,
-		.button.number = pad_button_as_uint32_t(pad_button),
+		.button.number = pad_button_as_uint32_t(button),
 		.button.state = state,
 		.mode_group = libinput_tablet_pad_mode_group_ref(group),
 		.mode = mode,
@@ -2928,7 +2898,7 @@ tablet_pad_notify_button(struct libinput_device *device,
 }
 
 void
-tablet_pad_notify_dial (struct libinput_device *device,
+tablet_pad_notify_dial(struct libinput_device *device,
 		       uint64_t time,
 		       unsigned int number,
 		       double value,
@@ -2952,7 +2922,7 @@ tablet_pad_notify_ring(struct libinput_device *device,
 
 	mode = libinput_tablet_pad_mode_group_get_mode(group);
 
-	*ring_event = (struct libinput_event_tablet_pad) {
+	*ring_event = (struct libinput_event_tablet_pad){
 		.time = time,
 		.ring.number = number,
 		.ring.position = value,
@@ -2982,7 +2952,7 @@ tablet_pad_notify_strip(struct libinput_device *device,
 
 	mode = libinput_tablet_pad_mode_group_get_mode(group);
 
-	*strip_event = (struct libinput_event_tablet_pad) {
+	*strip_event = (struct libinput_event_tablet_pad){
 		.time = time,
 		.strip.number = number,
 		.strip.position = value,
@@ -3007,7 +2977,7 @@ tablet_pad_notify_key(struct libinput_device *device,
 
 	key_event = zalloc(sizeof *key_event);
 
-	*key_event = (struct libinput_event_tablet_pad) {
+	*key_event = (struct libinput_event_tablet_pad){
 		.time = time,
 		.key.code = key,
 		.key.state = state,
@@ -3037,7 +3007,7 @@ gesture_notify(struct libinput_device *device,
 
 	gesture_event = zalloc(sizeof *gesture_event);
 
-	*gesture_event = (struct libinput_event_gesture) {
+	*gesture_event = (struct libinput_event_gesture){
 		.time = time,
 		.finger_count = finger_count,
 		.cancelled = cancelled,
@@ -3047,8 +3017,7 @@ gesture_notify(struct libinput_device *device,
 		.angle = angle,
 	};
 
-	post_device_event(device, time, type,
-			  &gesture_event->base);
+	post_device_event(device, time, type, &gesture_event->base);
 }
 
 void
@@ -3059,8 +3028,7 @@ gesture_notify_swipe(struct libinput_device *device,
 		     const struct normalized_coords *delta,
 		     const struct normalized_coords *unaccel)
 {
-	gesture_notify(device, time, type, finger_count, 0, delta, unaccel,
-		       0.0, 0.0);
+	gesture_notify(device, time, type, finger_count, 0, delta, unaccel, 0.0, 0.0);
 }
 
 void
@@ -3071,8 +3039,15 @@ gesture_notify_swipe_end(struct libinput_device *device,
 {
 	const struct normalized_coords zero = { 0.0, 0.0 };
 
-	gesture_notify(device, time, LIBINPUT_EVENT_GESTURE_SWIPE_END,
-		       finger_count, cancelled, &zero, &zero, 0.0, 0.0);
+	gesture_notify(device,
+		       time,
+		       LIBINPUT_EVENT_GESTURE_SWIPE_END,
+		       finger_count,
+		       cancelled,
+		       &zero,
+		       &zero,
+		       0.0,
+		       0.0);
 }
 
 void
@@ -3085,8 +3060,15 @@ gesture_notify_pinch(struct libinput_device *device,
 		     double scale,
 		     double angle)
 {
-	gesture_notify(device, time, type, finger_count, 0,
-		       delta, unaccel, scale, angle);
+	gesture_notify(device,
+		       time,
+		       type,
+		       finger_count,
+		       0,
+		       delta,
+		       unaccel,
+		       scale,
+		       angle);
 }
 
 void
@@ -3098,19 +3080,33 @@ gesture_notify_pinch_end(struct libinput_device *device,
 {
 	const struct normalized_coords zero = { 0.0, 0.0 };
 
-	gesture_notify(device, time, LIBINPUT_EVENT_GESTURE_PINCH_END,
-		       finger_count, cancelled, &zero, &zero, scale, 0.0);
+	gesture_notify(device,
+		       time,
+		       LIBINPUT_EVENT_GESTURE_PINCH_END,
+		       finger_count,
+		       cancelled,
+		       &zero,
+		       &zero,
+		       scale,
+		       0.0);
 }
 
 void
 gesture_notify_hold_begin(struct libinput_device *device,
-		    uint64_t time,
-		    int finger_count)
+			  uint64_t time,
+			  int finger_count)
 {
 	const struct normalized_coords zero = { 0.0, 0.0 };
 
-	gesture_notify(device, time, LIBINPUT_EVENT_GESTURE_HOLD_BEGIN,
-		       finger_count, 0, &zero, &zero, 0.0, 0.0);
+	gesture_notify(device,
+		       time,
+		       LIBINPUT_EVENT_GESTURE_HOLD_BEGIN,
+		       finger_count,
+		       0,
+		       &zero,
+		       &zero,
+		       0.0,
+		       0.0);
 }
 
 void
@@ -3121,8 +3117,15 @@ gesture_notify_hold_end(struct libinput_device *device,
 {
 	const struct normalized_coords zero = { 0.0, 0.0 };
 
-	gesture_notify(device, time, LIBINPUT_EVENT_GESTURE_HOLD_END,
-		       finger_count, cancelled, &zero, &zero, 0, 0.0);
+	gesture_notify(device,
+		       time,
+		       LIBINPUT_EVENT_GESTURE_HOLD_END,
+		       finger_count,
+		       cancelled,
+		       &zero,
+		       &zero,
+		       0,
+		       0.0);
 }
 
 void
@@ -3138,13 +3141,14 @@ switch_notify_toggle(struct libinput_device *device,
 
 	switch_event = zalloc(sizeof *switch_event);
 
-	*switch_event = (struct libinput_event_switch) {
+	*switch_event = (struct libinput_event_switch){
 		.time = time,
 		.sw = sw,
 		.state = state,
 	};
 
-	post_device_event(device, time,
+	post_device_event(device,
+			  time,
 			  LIBINPUT_EVENT_SWITCH_TOGGLE,
 			  &switch_event->base);
 
@@ -3162,8 +3166,7 @@ libinput_print_queued_event(struct libinput_event *event)
 }
 
 static void
-libinput_post_event(struct libinput *libinput,
-		    struct libinput_event *event)
+libinput_post_event(struct libinput *libinput, struct libinput_event *event)
 {
 	struct libinput_event **events = libinput->events;
 	size_t events_len = libinput->events_len;
@@ -3223,8 +3226,7 @@ libinput_get_event(struct libinput *libinput)
 		return NULL;
 
 	event = libinput->events[libinput->events_out];
-	libinput->events_out =
-		(libinput->events_out + 1) % libinput->events_len;
+	libinput->events_out = (libinput->events_out + 1) % libinput->events_len;
 	libinput->events_count--;
 
 	return event;
@@ -3243,8 +3245,7 @@ libinput_next_event_type(struct libinput *libinput)
 }
 
 LIBINPUT_EXPORT void
-libinput_set_user_data(struct libinput *libinput,
-		       void *user_data)
+libinput_set_user_data(struct libinput *libinput, void *user_data)
 {
 	libinput->user_data = user_data;
 }
@@ -3337,16 +3338,14 @@ libinput_device_get_seat(struct libinput_device *device)
 }
 
 LIBINPUT_EXPORT int
-libinput_device_set_seat_logical_name(struct libinput_device *device,
-				      const char *name)
+libinput_device_set_seat_logical_name(struct libinput_device *device, const char *name)
 {
 	struct libinput *libinput = device->seat->libinput;
 
 	if (name == NULL)
 		return -1;
 
-	return libinput->interface_backend->device_change_seat(device,
-							       name);
+	return libinput->interface_backend->device_change_seat(device, name);
 }
 
 LIBINPUT_EXPORT struct udev_device *
@@ -3356,8 +3355,7 @@ libinput_device_get_udev_device(struct libinput_device *device)
 }
 
 LIBINPUT_EXPORT void
-libinput_device_led_update(struct libinput_device *device,
-			   enum libinput_led leds)
+libinput_device_led_update(struct libinput_device *device, enum libinput_led leds)
 {
 	// TODO
 }
@@ -3370,9 +3368,7 @@ libinput_device_has_capability(struct libinput_device *device,
 }
 
 LIBINPUT_EXPORT int
-libinput_device_get_size(struct libinput_device *device,
-			 double *width,
-			 double *height)
+libinput_device_get_size(struct libinput_device *device, double *width, double *height)
 {
 	fprintf(stderr, "%s: stub\n", __func__);
 	return (-1);
@@ -3449,7 +3445,7 @@ libinput_device_tablet_pad_get_num_mode_groups(struct libinput_device *device)
 	return (-1);
 }
 
-LIBINPUT_EXPORT struct libinput_tablet_pad_mode_group*
+LIBINPUT_EXPORT struct libinput_tablet_pad_mode_group *
 libinput_device_tablet_pad_get_mode_group(struct libinput_device *device,
 					  unsigned int index)
 {
@@ -3459,7 +3455,7 @@ libinput_device_tablet_pad_get_mode_group(struct libinput_device *device,
 
 LIBINPUT_EXPORT unsigned int
 libinput_tablet_pad_mode_group_get_num_modes(
-				     struct libinput_tablet_pad_mode_group *group)
+	struct libinput_tablet_pad_mode_group *group)
 {
 	return group->num_modes;
 }
@@ -3480,8 +3476,7 @@ LIBINPUT_EXPORT int
 libinput_tablet_pad_mode_group_has_button(struct libinput_tablet_pad_mode_group *group,
 					  unsigned int button)
 {
-	if ((int)button >=
-	    libinput_device_tablet_pad_get_num_buttons(group->device))
+	if ((int)button >= libinput_device_tablet_pad_get_num_buttons(group->device))
 		return 0;
 
 	return !!(group->button_mask & bit(button));
@@ -3498,8 +3493,7 @@ LIBINPUT_EXPORT int
 libinput_tablet_pad_mode_group_has_ring(struct libinput_tablet_pad_mode_group *group,
 					unsigned int ring)
 {
-	if ((int)ring >=
-	    libinput_device_tablet_pad_get_num_rings(group->device))
+	if ((int)ring >= libinput_device_tablet_pad_get_num_rings(group->device))
 		return 0;
 
 	return !!(group->ring_mask & bit(ring));
@@ -3509,35 +3503,32 @@ LIBINPUT_EXPORT int
 libinput_tablet_pad_mode_group_has_strip(struct libinput_tablet_pad_mode_group *group,
 					 unsigned int strip)
 {
-	if ((int)strip >=
-	    libinput_device_tablet_pad_get_num_strips(group->device))
+	if ((int)strip >= libinput_device_tablet_pad_get_num_strips(group->device))
 		return 0;
 
 	return !!(group->strip_mask & bit(strip));
 }
 
 LIBINPUT_EXPORT int
-libinput_tablet_pad_mode_group_button_is_toggle(struct libinput_tablet_pad_mode_group *group,
-						unsigned int button)
+libinput_tablet_pad_mode_group_button_is_toggle(
+	struct libinput_tablet_pad_mode_group *group,
+	unsigned int button)
 {
-	if ((int)button >=
-	    libinput_device_tablet_pad_get_num_buttons(group->device))
+	if ((int)button >= libinput_device_tablet_pad_get_num_buttons(group->device))
 		return 0;
 
 	return !!(group->toggle_button_mask & bit(button));
 }
 
 LIBINPUT_EXPORT struct libinput_tablet_pad_mode_group *
-libinput_tablet_pad_mode_group_ref(
-			struct libinput_tablet_pad_mode_group *group)
+libinput_tablet_pad_mode_group_ref(struct libinput_tablet_pad_mode_group *group)
 {
 	group->refcount++;
 	return group;
 }
 
 LIBINPUT_EXPORT struct libinput_tablet_pad_mode_group *
-libinput_tablet_pad_mode_group_unref(
-			struct libinput_tablet_pad_mode_group *group)
+libinput_tablet_pad_mode_group_unref(struct libinput_tablet_pad_mode_group *group)
 {
 	assert(group->refcount > 0);
 
@@ -3552,15 +3543,15 @@ libinput_tablet_pad_mode_group_unref(
 
 LIBINPUT_EXPORT void
 libinput_tablet_pad_mode_group_set_user_data(
-			struct libinput_tablet_pad_mode_group *group,
-			void *user_data)
+	struct libinput_tablet_pad_mode_group *group,
+	void *user_data)
 {
 	group->user_data = user_data;
 }
 
 LIBINPUT_EXPORT void *
 libinput_tablet_pad_mode_group_get_user_data(
-			struct libinput_tablet_pad_mode_group *group)
+	struct libinput_tablet_pad_mode_group *group)
 {
 	return group->user_data;
 }
@@ -3855,8 +3846,7 @@ libinput_device_group_ref(struct libinput_device_group *group)
 }
 
 struct libinput_device_group *
-libinput_device_group_create(struct libinput *libinput,
-			     const char *identifier)
+libinput_device_group_create(struct libinput *libinput, const char *identifier)
 {
 	struct libinput_device_group *group;
 
@@ -3871,14 +3861,12 @@ libinput_device_group_create(struct libinput *libinput,
 }
 
 struct libinput_device_group *
-libinput_device_group_find_group(struct libinput *libinput,
-				 const char *identifier)
+libinput_device_group_find_group(struct libinput *libinput, const char *identifier)
 {
 	struct libinput_device_group *g = NULL;
 
 	list_for_each(g, &libinput->device_group_list, link) {
-		if (identifier && g->identifier &&
-		    streq(g->identifier, identifier)) {
+		if (identifier && g->identifier && streq(g->identifier, identifier)) {
 			return g;
 		}
 	}
@@ -3933,7 +3921,7 @@ libinput_config_status_to_str(enum libinput_config_status status)
 {
 	const char *str = NULL;
 
-	switch(status) {
+	switch (status) {
 	case LIBINPUT_CONFIG_STATUS_SUCCESS:
 		str = "Success";
 		break;
@@ -3963,11 +3951,10 @@ libinput_device_config_tap_set_enabled(struct libinput_device *device,
 		return LIBINPUT_CONFIG_STATUS_INVALID;
 
 	if (libinput_device_config_tap_get_finger_count(device) == 0)
-		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED :
-				LIBINPUT_CONFIG_STATUS_SUCCESS;
+		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED
+			      : LIBINPUT_CONFIG_STATUS_SUCCESS;
 
 	return device->config.tap->set_enabled(device, enable);
-
 }
 
 LIBINPUT_EXPORT enum libinput_config_tap_state
@@ -3990,7 +3977,7 @@ libinput_device_config_tap_get_default_enabled(struct libinput_device *device)
 
 LIBINPUT_EXPORT enum libinput_config_status
 libinput_device_config_tap_set_button_map(struct libinput_device *device,
-					    enum libinput_config_tap_button_map map)
+					  enum libinput_config_tap_button_map map)
 {
 	switch (map) {
 	case LIBINPUT_CONFIG_TAP_MAP_LRM:
@@ -4033,8 +4020,8 @@ libinput_device_config_tap_set_drag_enabled(struct libinput_device *device,
 		return LIBINPUT_CONFIG_STATUS_INVALID;
 
 	if (libinput_device_config_tap_get_finger_count(device) == 0)
-		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED :
-				LIBINPUT_CONFIG_STATUS_SUCCESS;
+		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED
+			      : LIBINPUT_CONFIG_STATUS_SUCCESS;
 
 	return device->config.tap->set_drag_enabled(device, enable);
 }
@@ -4058,16 +4045,17 @@ libinput_device_config_tap_get_default_drag_enabled(struct libinput_device *devi
 }
 
 LIBINPUT_EXPORT enum libinput_config_status
-libinput_device_config_tap_set_drag_lock_enabled(struct libinput_device *device,
-						 enum libinput_config_drag_lock_state enable)
+libinput_device_config_tap_set_drag_lock_enabled(
+	struct libinput_device *device,
+	enum libinput_config_drag_lock_state enable)
 {
 	if (enable != LIBINPUT_CONFIG_DRAG_LOCK_ENABLED &&
 	    enable != LIBINPUT_CONFIG_DRAG_LOCK_DISABLED)
 		return LIBINPUT_CONFIG_STATUS_INVALID;
 
 	if (libinput_device_config_tap_get_finger_count(device) == 0)
-		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED :
-				LIBINPUT_CONFIG_STATUS_SUCCESS;
+		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED
+			      : LIBINPUT_CONFIG_STATUS_SUCCESS;
 
 	return device->config.tap->set_draglock_enabled(device, enable);
 }
@@ -4096,6 +4084,13 @@ libinput_device_config_3fg_drag_get_finger_count(struct libinput_device *device)
 	return 0;
 }
 
+LIBINPUT_EXPORT enum libinput_config_status
+libinput_device_config_3fg_drag_set_enabled(struct libinput_device *device,
+					    enum libinput_config_3fg_drag_state enable)
+{
+	return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
+}
+
 LIBINPUT_EXPORT enum libinput_config_3fg_drag_state
 libinput_device_config_3fg_drag_get_enabled(struct libinput_device *device)
 {
@@ -4108,19 +4103,12 @@ libinput_device_config_3fg_drag_get_default_enabled(struct libinput_device *devi
 	return LIBINPUT_CONFIG_3FG_DRAG_DISABLED;
 }
 
-LIBINPUT_EXPORT enum libinput_config_status
-libinput_device_config_3fg_drag_set_enabled(struct libinput_device *device,
-					    enum libinput_config_3fg_drag_state enable)
-{
-	return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
-}
-
-
 LIBINPUT_EXPORT int
 libinput_device_config_calibration_has_matrix(struct libinput_device *device)
 {
-	return device->config.calibration ?
-		device->config.calibration->has_matrix(device) : 0;
+	return device->config.calibration
+		       ? device->config.calibration->has_matrix(device)
+		       : 0;
 }
 
 LIBINPUT_EXPORT enum libinput_config_status
@@ -4183,7 +4171,6 @@ libinput_device_config_area_get_default_rectangle(struct libinput_device *device
 	return rect;
 }
 
-
 LIBINPUT_EXPORT uint32_t
 libinput_device_config_send_events_get_modes(struct libinput_device *device)
 {
@@ -4227,13 +4214,11 @@ libinput_device_config_send_events_get_default_mode(struct libinput_device *devi
 LIBINPUT_EXPORT int
 libinput_device_config_accel_is_available(struct libinput_device *device)
 {
-	return device->config.accel ?
-		device->config.accel->available(device) : 0;
+	return device->config.accel ? device->config.accel->available(device) : 0;
 }
 
 LIBINPUT_EXPORT enum libinput_config_status
-libinput_device_config_accel_set_speed(struct libinput_device *device,
-				       double speed)
+libinput_device_config_accel_set_speed(struct libinput_device *device, double speed)
 {
 	/* Need the negation in case speed is NaN */
 	if (!(speed >= -1.0 && speed <= 1.0))
@@ -4323,7 +4308,8 @@ libinput_config_accel_custom_func_create(void)
 }
 
 static inline void
-libinput_config_accel_custom_func_destroy(struct libinput_config_accel_custom_func * func)
+libinput_config_accel_custom_func_destroy(
+	struct libinput_config_accel_custom_func *func)
 {
 	free(func);
 }
@@ -4364,14 +4350,14 @@ libinput_device_config_accel_apply(struct libinput_device *device,
 				   struct libinput_config_accel *accel_config)
 {
 	enum libinput_config_status status;
-	status = libinput_device_config_accel_set_profile(device, accel_config->profile);
+	status =
+		libinput_device_config_accel_set_profile(device, accel_config->profile);
 	if (status != LIBINPUT_CONFIG_STATUS_SUCCESS)
 		return status;
 
 	switch (accel_config->profile) {
 	case LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT:
-	case LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE:
-	{
+	case LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE: {
 		double speed = libinput_device_config_accel_get_default_speed(device);
 		return libinput_device_config_accel_set_speed(device, speed);
 	}
@@ -4386,7 +4372,9 @@ libinput_device_config_accel_apply(struct libinput_device *device,
 LIBINPUT_EXPORT enum libinput_config_status
 libinput_config_accel_set_points(struct libinput_config_accel *config,
 				 enum libinput_config_accel_type accel_type,
-				 double step, size_t npoints, const double *points)
+				 double step,
+				 size_t npoints,
+				 const double *points)
 {
 	if (config->profile != LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM)
 		return LIBINPUT_CONFIG_STATUS_INVALID;
@@ -4403,7 +4391,8 @@ libinput_config_accel_set_points(struct libinput_config_accel *config,
 	if (step <= 0 || step > LIBINPUT_ACCEL_STEP_MAX)
 		return LIBINPUT_CONFIG_STATUS_INVALID;
 
-	if (npoints < LIBINPUT_ACCEL_NPOINTS_MIN || npoints > LIBINPUT_ACCEL_NPOINTS_MAX)
+	if (npoints < LIBINPUT_ACCEL_NPOINTS_MIN ||
+	    npoints > LIBINPUT_ACCEL_NPOINTS_MAX)
 		return LIBINPUT_CONFIG_STATUS_INVALID;
 
 	for (size_t idx = 0; idx < npoints; idx++) {
@@ -4412,7 +4401,8 @@ libinput_config_accel_set_points(struct libinput_config_accel *config,
 			return LIBINPUT_CONFIG_STATUS_INVALID;
 	}
 
-	struct libinput_config_accel_custom_func *func = libinput_config_accel_custom_func_create();
+	struct libinput_config_accel_custom_func *func =
+		libinput_config_accel_custom_func_create();
 
 	func->step = step;
 	func->npoints = npoints;
@@ -4465,7 +4455,8 @@ libinput_device_config_scroll_get_natural_scroll_enabled(struct libinput_device 
 }
 
 LIBINPUT_EXPORT int
-libinput_device_config_scroll_get_default_natural_scroll_enabled(struct libinput_device *device)
+libinput_device_config_scroll_get_default_natural_scroll_enabled(
+	struct libinput_device *device)
 {
 	if (!device->config.natural_scroll)
 		return 0;
@@ -4483,8 +4474,7 @@ libinput_device_config_left_handed_is_available(struct libinput_device *device)
 }
 
 LIBINPUT_EXPORT enum libinput_config_status
-libinput_device_config_left_handed_set(struct libinput_device *device,
-				       int left_handed)
+libinput_device_config_left_handed_set(struct libinput_device *device, int left_handed)
 {
 	if (!libinput_device_config_left_handed_is_available(device))
 		return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
@@ -4562,8 +4552,9 @@ libinput_device_config_click_get_default_method(struct libinput_device *device)
 }
 
 LIBINPUT_EXPORT enum libinput_config_status
-libinput_device_config_click_set_clickfinger_button_map(struct libinput_device *device,
-							enum libinput_config_clickfinger_button_map map)
+libinput_device_config_click_set_clickfinger_button_map(
+	struct libinput_device *device,
+	enum libinput_config_clickfinger_button_map map)
 {
 	switch (map) {
 	case LIBINPUT_CONFIG_CLICKFINGER_MAP_LRM:
@@ -4574,7 +4565,8 @@ libinput_device_config_click_set_clickfinger_button_map(struct libinput_device *
 	}
 
 	if ((libinput_device_config_click_get_methods(device) &
-	     LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER) != LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER)
+	     LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER) !=
+	    LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER)
 		return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
 
 	return device->config.click_method->set_clickfinger_map(device, map);
@@ -4584,25 +4576,27 @@ LIBINPUT_EXPORT enum libinput_config_clickfinger_button_map
 libinput_device_config_click_get_clickfinger_button_map(struct libinput_device *device)
 {
 	if ((libinput_device_config_click_get_methods(device) &
-	     LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER) != LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER)
+	     LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER) !=
+	    LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER)
 		return LIBINPUT_CONFIG_CLICKFINGER_MAP_LRM;
 
 	return device->config.click_method->get_clickfinger_map(device);
 }
 
 LIBINPUT_EXPORT enum libinput_config_clickfinger_button_map
-libinput_device_config_click_get_default_clickfinger_button_map(struct libinput_device *device)
+libinput_device_config_click_get_default_clickfinger_button_map(
+	struct libinput_device *device)
 {
 	if ((libinput_device_config_click_get_methods(device) &
-	     LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER) != LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER)
+	     LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER) !=
+	    LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER)
 		return LIBINPUT_CONFIG_CLICKFINGER_MAP_LRM;
 
 	return device->config.click_method->get_default_clickfinger_map(device);
 }
 
 LIBINPUT_EXPORT int
-libinput_device_config_middle_emulation_is_available(
-		struct libinput_device *device)
+libinput_device_config_middle_emulation_is_available(struct libinput_device *device)
 {
 	if (device->config.middle_emulation)
 		return device->config.middle_emulation->available(device);
@@ -4612,11 +4606,10 @@ libinput_device_config_middle_emulation_is_available(
 
 LIBINPUT_EXPORT enum libinput_config_status
 libinput_device_config_middle_emulation_set_enabled(
-		struct libinput_device *device,
-		enum libinput_config_middle_emulation_state enable)
+	struct libinput_device *device,
+	enum libinput_config_middle_emulation_state enable)
 {
-	int available =
-		libinput_device_config_middle_emulation_is_available(device);
+	int available = libinput_device_config_middle_emulation_is_available(device);
 
 	switch (enable) {
 	case LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED:
@@ -4635,8 +4628,7 @@ libinput_device_config_middle_emulation_set_enabled(
 }
 
 LIBINPUT_EXPORT enum libinput_config_middle_emulation_state
-libinput_device_config_middle_emulation_get_enabled(
-		struct libinput_device *device)
+libinput_device_config_middle_emulation_get_enabled(struct libinput_device *device)
 {
 	if (!libinput_device_config_middle_emulation_is_available(device))
 		return LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED;
@@ -4646,7 +4638,7 @@ libinput_device_config_middle_emulation_get_enabled(
 
 LIBINPUT_EXPORT enum libinput_config_middle_emulation_state
 libinput_device_config_middle_emulation_get_default_enabled(
-		struct libinput_device *device)
+	struct libinput_device *device)
 {
 	if (!libinput_device_config_middle_emulation_is_available(device))
 		return LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED;
@@ -4741,8 +4733,9 @@ libinput_device_config_scroll_get_default_button(struct libinput_device *device)
 }
 
 LIBINPUT_EXPORT enum libinput_config_status
-libinput_device_config_scroll_set_button_lock(struct libinput_device *device,
-					      enum libinput_config_scroll_button_lock_state state)
+libinput_device_config_scroll_set_button_lock(
+	struct libinput_device *device,
+	enum libinput_config_scroll_button_lock_state state)
 {
 	if ((libinput_device_config_scroll_get_methods(device) &
 	     LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN) == 0)
@@ -4797,8 +4790,8 @@ libinput_device_config_dwt_set_enabled(struct libinput_device *device,
 		return LIBINPUT_CONFIG_STATUS_INVALID;
 
 	if (!libinput_device_config_dwt_is_available(device))
-		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED :
-				LIBINPUT_CONFIG_STATUS_SUCCESS;
+		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED
+			      : LIBINPUT_CONFIG_STATUS_SUCCESS;
 
 	return device->config.dwt->set_enabled(device, enable);
 }
@@ -4832,15 +4825,15 @@ libinput_device_config_dwtp_is_available(struct libinput_device *device)
 
 LIBINPUT_EXPORT enum libinput_config_status
 libinput_device_config_dwtp_set_enabled(struct libinput_device *device,
-				       enum libinput_config_dwtp_state enable)
+					enum libinput_config_dwtp_state enable)
 {
 	if (enable != LIBINPUT_CONFIG_DWTP_ENABLED &&
 	    enable != LIBINPUT_CONFIG_DWTP_DISABLED)
 		return LIBINPUT_CONFIG_STATUS_INVALID;
 
 	if (!libinput_device_config_dwtp_is_available(device))
-		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED :
-				LIBINPUT_CONFIG_STATUS_SUCCESS;
+		return enable ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED
+			      : LIBINPUT_CONFIG_STATUS_SUCCESS;
 
 	return device->config.dwtp->set_enabled(device, enable);
 }
@@ -4877,8 +4870,8 @@ libinput_device_config_rotation_set_angle(struct libinput_device *device,
 					  unsigned int degrees_cw)
 {
 	if (!libinput_device_config_rotation_is_available(device))
-		return degrees_cw ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED :
-				    LIBINPUT_CONFIG_STATUS_SUCCESS;
+		return degrees_cw ? LIBINPUT_CONFIG_STATUS_UNSUPPORTED
+				  : LIBINPUT_CONFIG_STATUS_SUCCESS;
 
 	if (degrees_cw >= 360)
 		return LIBINPUT_CONFIG_STATUS_INVALID;
@@ -4996,14 +4989,13 @@ libinput_tablet_tool_config_eraser_button_get_button(struct libinput_tablet_tool
 }
 
 LIBINPUT_EXPORT unsigned int
-libinput_tablet_tool_config_eraser_button_get_default_button(struct libinput_tablet_tool *tool)
+libinput_tablet_tool_config_eraser_button_get_default_button(
+	struct libinput_tablet_tool *tool)
 {
 	return 0;
 }
 
-
 /* These are implemented by libinput-plugin.c */
-
 LIBINPUT_EXPORT void
 libinput_plugin_system_append_path(struct libinput *libinput, const char *path)
 {
@@ -5029,3 +5021,10 @@ libinput_plugin_system_load_plugins(struct libinput *libinput,
 	return -ENOSYS;
 }
 
+#ifdef HAVE_LIBWACOM
+WacomDeviceDatabase *
+libinput_libwacom_ref(struct libinput *li)
+{
+	return NULL;
+}
+#endif

--- a/src/libinput_openbsd.c
+++ b/src/libinput_openbsd.c
@@ -1942,6 +1942,11 @@ libinput_unref(struct libinput *libinput)
 	return NULL;
 }
 
+struct quirks *
+libinput_device_get_quirks(struct libinput_device *device) {
+	return NULL;
+}
+
 static void
 libinput_event_tablet_tool_destroy(struct libinput_event_tablet_tool *event)
 {
@@ -2123,6 +2128,13 @@ libinput_device_unref(struct libinput_device *device)
 	return device;
 }
 
+void
+libinput_device_disable_feature(struct libinput_device *device,
+		                enum libinput_feature feature)
+{
+	return;
+}
+
 LIBINPUT_EXPORT int
 libinput_get_fd(struct libinput *libinput)
 {
@@ -2186,6 +2198,18 @@ void
 libinput_device_remove_event_listener(struct libinput_event_listener *listener)
 {
 	list_remove(&listener->link);
+}
+
+bool
+libinput_device_has_model_quirk(struct libinput_device *device, enum quirk model_quirk)
+{
+	return false;
+}
+
+bool
+libinput_device_is_virtual(struct libinput_device *device)
+{
+	return false;
 }
 
 static uint32_t
@@ -2904,6 +2928,16 @@ tablet_pad_notify_button(struct libinput_device *device,
 }
 
 void
+tablet_pad_notify_dial (struct libinput_device *device,
+		       uint64_t time,
+		       unsigned int number,
+		       double value,
+		       struct libinput_tablet_pad_mode_group *group)
+{
+	return;
+}
+
+void
 tablet_pad_notify_ring(struct libinput_device *device,
 		       uint64_t time,
 		       unsigned int number,
@@ -3121,6 +3155,12 @@ switch_notify_toggle(struct libinput_device *device,
 #endif
 }
 
+_unused_ static inline void
+libinput_print_queued_event(struct libinput_event *event)
+{
+	return;
+}
+
 static void
 libinput_post_event(struct libinput *libinput,
 		    struct libinput_event *event)
@@ -3267,6 +3307,12 @@ libinput_device_get_name(struct libinput_device *device)
 }
 
 LIBINPUT_EXPORT unsigned int
+libinput_device_get_id_bustype(struct libinput_device *device)
+{
+	return 0; // TODO
+}
+
+LIBINPUT_EXPORT unsigned int
 libinput_device_get_id_product(struct libinput_device *device)
 {
 	return 0; // TODO
@@ -3376,6 +3422,13 @@ libinput_device_tablet_pad_get_num_buttons(struct libinput_device *device)
 }
 
 LIBINPUT_EXPORT int
+libinput_device_tablet_pad_get_num_dials(struct libinput_device *device)
+{
+	fprintf(stderr, "%s: stub\n", __func__);
+	return (-1);
+}
+
+LIBINPUT_EXPORT int
 libinput_device_tablet_pad_get_num_rings(struct libinput_device *device)
 {
 	fprintf(stderr, "%s: stub\n", __func__);
@@ -3432,6 +3485,13 @@ libinput_tablet_pad_mode_group_has_button(struct libinput_tablet_pad_mode_group 
 		return 0;
 
 	return !!(group->button_mask & bit(button));
+}
+
+LIBINPUT_EXPORT int
+libinput_tablet_pad_mode_group_has_dial(struct libinput_tablet_pad_mode_group *group,
+					unsigned int dial)
+{
+	return false;
 }
 
 LIBINPUT_EXPORT int
@@ -3593,6 +3653,18 @@ libinput_event_tablet_tool_get_base_event(struct libinput_event_tablet_tool *eve
 }
 
 LIBINPUT_EXPORT double
+libinput_event_tablet_pad_get_dial_delta_v120(struct libinput_event_tablet_pad *event)
+{
+	return 0.0;
+}
+
+LIBINPUT_EXPORT unsigned int
+libinput_event_tablet_pad_get_dial_number(struct libinput_event_tablet_pad *event)
+{
+	return 0;
+}
+
+LIBINPUT_EXPORT double
 libinput_event_tablet_pad_get_ring_position(struct libinput_event_tablet_pad *event)
 {
 	require_event_type(libinput_event_get_context(&event->base),
@@ -3709,6 +3781,7 @@ libinput_event_tablet_pad_get_mode(struct libinput_event_tablet_pad *event)
 			   event->base.type,
 			   0,
 			   LIBINPUT_EVENT_TABLET_PAD_RING,
+			   LIBINPUT_EVENT_TABLET_PAD_DIAL,
 			   LIBINPUT_EVENT_TABLET_PAD_STRIP,
 			   LIBINPUT_EVENT_TABLET_PAD_BUTTON);
 
@@ -3722,6 +3795,7 @@ libinput_event_tablet_pad_get_mode_group(struct libinput_event_tablet_pad *event
 			   event->base.type,
 			   NULL,
 			   LIBINPUT_EVENT_TABLET_PAD_RING,
+			   LIBINPUT_EVENT_TABLET_PAD_DIAL,
 			   LIBINPUT_EVENT_TABLET_PAD_STRIP,
 			   LIBINPUT_EVENT_TABLET_PAD_BUTTON);
 
@@ -3735,6 +3809,7 @@ libinput_event_tablet_pad_get_time(struct libinput_event_tablet_pad *event)
 			   event->base.type,
 			   0,
 			   LIBINPUT_EVENT_TABLET_PAD_RING,
+			   LIBINPUT_EVENT_TABLET_PAD_DIAL,
 			   LIBINPUT_EVENT_TABLET_PAD_STRIP,
 			   LIBINPUT_EVENT_TABLET_PAD_BUTTON,
 			   LIBINPUT_EVENT_TABLET_PAD_KEY);
@@ -3749,6 +3824,7 @@ libinput_event_tablet_pad_get_time_usec(struct libinput_event_tablet_pad *event)
 			   event->base.type,
 			   0,
 			   LIBINPUT_EVENT_TABLET_PAD_RING,
+			   LIBINPUT_EVENT_TABLET_PAD_DIAL,
 			   LIBINPUT_EVENT_TABLET_PAD_STRIP,
 			   LIBINPUT_EVENT_TABLET_PAD_BUTTON,
 			   LIBINPUT_EVENT_TABLET_PAD_KEY);
@@ -3763,6 +3839,7 @@ libinput_event_tablet_pad_get_base_event(struct libinput_event_tablet_pad *event
 			   event->base.type,
 			   NULL,
 			   LIBINPUT_EVENT_TABLET_PAD_RING,
+			   LIBINPUT_EVENT_TABLET_PAD_DIAL,
 			   LIBINPUT_EVENT_TABLET_PAD_STRIP,
 			   LIBINPUT_EVENT_TABLET_PAD_BUTTON,
 			   LIBINPUT_EVENT_TABLET_PAD_KEY);
@@ -4014,6 +4091,32 @@ libinput_device_config_tap_get_default_drag_lock_enabled(struct libinput_device 
 }
 
 LIBINPUT_EXPORT int
+libinput_device_config_3fg_drag_get_finger_count(struct libinput_device *device)
+{
+	return 0;
+}
+
+LIBINPUT_EXPORT enum libinput_config_3fg_drag_state
+libinput_device_config_3fg_drag_get_enabled(struct libinput_device *device)
+{
+	return LIBINPUT_CONFIG_3FG_DRAG_DISABLED;
+}
+
+LIBINPUT_EXPORT enum libinput_config_3fg_drag_state
+libinput_device_config_3fg_drag_get_default_enabled(struct libinput_device *device)
+{
+	return LIBINPUT_CONFIG_3FG_DRAG_DISABLED;
+}
+
+LIBINPUT_EXPORT enum libinput_config_status
+libinput_device_config_3fg_drag_set_enabled(struct libinput_device *device,
+					    enum libinput_config_3fg_drag_state enable)
+{
+	return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
+}
+
+
+LIBINPUT_EXPORT int
 libinput_device_config_calibration_has_matrix(struct libinput_device *device)
 {
 	return device->config.calibration ?
@@ -4049,6 +4152,37 @@ libinput_device_config_calibration_get_default_matrix(struct libinput_device *de
 
 	return device->config.calibration->get_default_matrix(device, matrix);
 }
+
+LIBINPUT_EXPORT int
+libinput_device_config_area_has_rectangle(struct libinput_device *device)
+{
+	return device->config.area ? device->config.area->has_rectangle(device) : 0;
+}
+
+LIBINPUT_EXPORT enum libinput_config_status
+libinput_device_config_area_set_rectangle(
+	struct libinput_device *device,
+	const struct libinput_config_area_rectangle *rectangle)
+{
+	return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
+}
+
+LIBINPUT_EXPORT struct libinput_config_area_rectangle
+libinput_device_config_area_get_rectangle(struct libinput_device *device)
+{
+	struct libinput_config_area_rectangle rect = { 0.0, 0.0, 1.0, 1.0 };
+
+	return rect;
+}
+
+LIBINPUT_EXPORT struct libinput_config_area_rectangle
+libinput_device_config_area_get_default_rectangle(struct libinput_device *device)
+{
+	struct libinput_config_area_rectangle rect = { 0.0, 0.0, 1.0, 1.0 };
+
+	return rect;
+}
+
 
 LIBINPUT_EXPORT uint32_t
 libinput_device_config_send_events_get_modes(struct libinput_device *device)
@@ -4770,84 +4904,55 @@ libinput_device_config_rotation_get_default_angle(struct libinput_device *device
 	return device->config.rotation->get_default_angle(device);
 }
 
-LIBINPUT_EXPORT void
-libinput_plugin_system_append_path(struct libinput *libinput, const char *path)
-{
-	/* We don't support libinput plugins */
-	return;
-}
-
-LIBINPUT_EXPORT void
-libinput_plugin_system_append_default_paths(struct libinput *libinput)
-{
-	/* We don't support libinput plugins */
-	return;
-}
-
 LIBINPUT_EXPORT int
-libinput_plugin_system_load_plugins(struct libinput *libinput,
-				    enum libinput_plugin_system_flags flags)
-{
-	/* We don't support libinput plugins.
-	 * Return -ENOSYS as the original implementation does
-	 * when #HAVE_PLUGINS is false
-	 */
-	return -ENOSYS;
-}
-
-LIBINPUT_EXPORT int
-libinput_device_config_3fg_drag_get_finger_count(struct libinput_device *device)
+libinput_tablet_tool_config_pressure_range_is_available(
+	struct libinput_tablet_tool *tool)
 {
 	return 0;
 }
 
-LIBINPUT_EXPORT enum libinput_config_3fg_drag_state
-libinput_device_config_3fg_drag_get_enabled(struct libinput_device *device)
-{
-	return LIBINPUT_CONFIG_3FG_DRAG_DISABLED;
-}
-
-LIBINPUT_EXPORT enum libinput_config_3fg_drag_state
-libinput_device_config_3fg_drag_get_default_enabled(struct libinput_device *device)
-{
-	return LIBINPUT_CONFIG_3FG_DRAG_DISABLED;
-}
-
 LIBINPUT_EXPORT enum libinput_config_status
-libinput_device_config_3fg_drag_set_enabled(struct libinput_device *device,
-					    enum libinput_config_3fg_drag_state enable)
+libinput_tablet_tool_config_pressure_range_set(struct libinput_tablet_tool *tool,
+					       double minimum,
+					       double maximum)
 {
 	return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
 }
 
-LIBINPUT_EXPORT int
-libinput_device_config_area_has_rectangle(struct libinput_device *device)
+LIBINPUT_EXPORT double
+libinput_tablet_tool_config_pressure_range_get_minimum(
+	struct libinput_tablet_tool *tool)
 {
-	return device->config.area ? device->config.area->has_rectangle(device) : 0;
+	double min = 0.0;
+
+	return min;
 }
 
-LIBINPUT_EXPORT enum libinput_config_status
-libinput_device_config_area_set_rectangle(
-	struct libinput_device *device,
-	const struct libinput_config_area_rectangle *rectangle)
+LIBINPUT_EXPORT double
+libinput_tablet_tool_config_pressure_range_get_maximum(
+	struct libinput_tablet_tool *tool)
 {
-	return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
+	double max = 1.0;
+
+	return max;
 }
 
-LIBINPUT_EXPORT struct libinput_config_area_rectangle
-libinput_device_config_area_get_rectangle(struct libinput_device *device)
+LIBINPUT_EXPORT double
+libinput_tablet_tool_config_pressure_range_get_default_minimum(
+	struct libinput_tablet_tool *tool)
 {
-	struct libinput_config_area_rectangle rect = { 0.0, 0.0, 1.0, 1.0 };
+	double min = 0.0;
 
-	return rect;
+	return min;
 }
 
-LIBINPUT_EXPORT struct libinput_config_area_rectangle
-libinput_device_config_area_get_default_rectangle(struct libinput_device *device)
+LIBINPUT_EXPORT double
+libinput_tablet_tool_config_pressure_range_get_default_maximum(
+	struct libinput_tablet_tool *tool)
 {
-	struct libinput_config_area_rectangle rect = { 0.0, 0.0, 1.0, 1.0 };
+	double max = 1.0;
 
-	return rect;
+	return max;
 }
 
 LIBINPUT_EXPORT uint32_t
@@ -4895,3 +5000,32 @@ libinput_tablet_tool_config_eraser_button_get_default_button(struct libinput_tab
 {
 	return 0;
 }
+
+
+/* These are implemented by libinput-plugin.c */
+
+LIBINPUT_EXPORT void
+libinput_plugin_system_append_path(struct libinput *libinput, const char *path)
+{
+	/* We don't support libinput plugins */
+	return;
+}
+
+LIBINPUT_EXPORT void
+libinput_plugin_system_append_default_paths(struct libinput *libinput)
+{
+	/* We don't support libinput plugins */
+	return;
+}
+
+LIBINPUT_EXPORT int
+libinput_plugin_system_load_plugins(struct libinput *libinput,
+				    enum libinput_plugin_system_flags flags)
+{
+	/* We don't support libinput plugins.
+	 * Return -ENOSYS as the original implementation does
+	 * when #HAVE_PLUGINS is false
+	 */
+	return -ENOSYS;
+}
+


### PR DESCRIPTION
This applies upstream's formatting rules to libinput_openbsd.c and reorders functions in line with libinput.c - while that may appear gratuitous, it will help a lot when merging new / changed upstream interfaces.
While here, I discovered a few more functions to add stubs for. It's a giant diff, I know, but I believe it'll pay off in the future.