### PR TITLE
Remove our custom axis_notify_event() function in libinput_openbsd.c

### DIFF
--- a/src/libinput-private.h
+++ b/src/libinput-private.h
@@ -1149,14 +1149,4 @@ libinput_libwacom_unref(struct libinput *li)
 }
 #endif
 
-
-#if defined(__OpenBSD__) || defined(__NetBSD__)
-void
-axis_notify_event(struct libinput_device *device,
-    uint64_t time,
-    const struct normalized_coords *delta,
-    const struct device_float_coords *raw);
-#endif
-
-
 #endif /* LIBINPUT_PRIVATE_H */

--- a/src/libinput_openbsd.c
+++ b/src/libinput_openbsd.c
@@ -2382,44 +2382,6 @@ keyboard_notify_key(struct libinput_device *device,
 }
 
 void
-axis_notify_event(struct libinput_device *device,
-		  uint64_t time,
-		  const struct normalized_coords *delta,
-		  const struct device_float_coords *raw)
-{
-	struct libinput_event_pointer *axis_event;
-	struct wheel_v120 v120 = { 0.0, 0.0 };
-	uint32_t axes;
-
-	axis_event = zalloc(sizeof *axis_event);
-	if (!axis_event)
-		return;
-	if (delta->x) {
-		axes = bit(LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL);
-		v120.x = delta->x * 3.75;
-	} else {
-		axes = bit(LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL);
-		v120.y = delta->y * 3.75;
-	}
-
-	*axis_event = (struct libinput_event_pointer){
-		.time = time,
-		.delta = *delta,
-		.delta_raw = *raw,
-		.source = LIBINPUT_POINTER_AXIS_SOURCE_WHEEL,
-		.axes = axes,
-		.discrete.x = 0,
-		.discrete.y = 0,
-		.v120 = v120
-	};
-
-	post_device_event(device,
-			  time,
-			  LIBINPUT_EVENT_POINTER_SCROLL_WHEEL,
-			  &axis_event->base);
-}
-
-void
 pointer_notify_motion(struct libinput_device *device,
 		      uint64_t time,
 		      const struct normalized_coords *delta,
@@ -2604,10 +2566,9 @@ pointer_notify_axis_wheel(struct libinput_device *device,
 {
 	struct libinput_event_pointer *axis_event;
 
-	if (!device_has_cap(device, LIBINPUT_DEVICE_CAP_POINTER))
-		return;
-
 	axis_event = zalloc(sizeof *axis_event);
+	if (!axis_event)
+		return;
 
 	*axis_event = (struct libinput_event_pointer){
 		.time = time,

--- a/src/wscons.c
+++ b/src/wscons.c
@@ -215,7 +215,7 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 	case WSCONS_EVENT_HSCROLL:
 		delta.x = wsevent->value / 8;
 		delta.y = 0;
-		v120.x = wsevent->value * 3;
+		v120.x = wsevent->value / 16;
 		v120.y = 0;
 		pointer_notify_axis_wheel(device, time,
 		                          bit(LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL),
@@ -225,7 +225,7 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 		delta.x = 0;
 		delta.y = wsevent->value / 8;
 		v120.x = 0;
-		v120.y = wsevent->value * 3;
+		v120.y = wsevent->value / 16;
 		pointer_notify_axis_wheel(device, time,
 		                          bit(LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL),
 		                          &delta, &v120);

--- a/src/wscons.c
+++ b/src/wscons.c
@@ -113,7 +113,8 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 {
 	enum libinput_button_state bstate;
 	enum libinput_key_state kstate;
-	struct normalized_coords accel;
+	struct normalized_coords delta = { 0, 0};
+	struct wheel_v120 v120 = { 0.0, 0.0 };
 	struct device_float_coords raw;
 	struct wscons_device *dev = wscons_device(device);
 	uint64_t time;
@@ -167,7 +168,6 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 	case WSCONS_EVENT_MOUSE_DELTA_X:
 	case WSCONS_EVENT_MOUSE_DELTA_Y:
 		memset(&raw, 0, sizeof(raw));
-		memset(&accel, 0, sizeof(accel));
 
 		if (wsevent->type == WSCONS_EVENT_MOUSE_DELTA_X)
 			raw.x = wsevent->value;
@@ -175,30 +175,36 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 			raw.y = -wsevent->value;
 
 		if (dev->pointer.filter) {
-			accel = filter_dispatch(dev->pointer.filter,
+			delta = filter_dispatch(dev->pointer.filter,
 			                        &raw,
 			                	device,
 			                	time);
 		} else {
-			accel.x = raw.x;
-			accel.y = raw.y;
+			delta.x = raw.x;
+			delta.y = raw.y;
 		}
 
-		pointer_notify_motion(device, time, &accel, &raw);
+		pointer_notify_motion(device, time, &delta, &raw);
 		break;
 
 	case WSCONS_EVENT_MOUSE_DELTA_Z:
-		memset(&raw, 0, sizeof(raw));
-		accel.x = 0;
-		accel.y = wsevent->value * 32;
-		axis_notify_event(device, time, &accel, &raw);
+		delta.x = 0;
+		delta.y = wsevent->value * 32;
+		v120.x = 0;
+		v120.y = wsevent->value * 120;
+		pointer_notify_axis_wheel(device, time,
+		                          bit(LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL),
+		                          &delta, &v120);
 		break;
 
 	case WSCONS_EVENT_MOUSE_DELTA_W:
-		memset(&raw, 0, sizeof(raw));
-		accel.x = wsevent->value * 32;
-		accel.y = 0;
-		axis_notify_event(device, time, &accel, &raw);
+		delta.x = wsevent->value * 32;
+		delta.y = 0;
+		v120.x = wsevent->value * 120;
+		v120.y = 0;
+		pointer_notify_axis_wheel(device, time,
+		                          bit(LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL),
+		                          &delta, &v120);
 		break;
 
 	case WSCONS_EVENT_MOUSE_ABSOLUTE_X:
@@ -207,16 +213,22 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 		break;
 
 	case WSCONS_EVENT_HSCROLL:
-		memset(&raw, 0, sizeof(raw));
-		accel.x = wsevent->value/8;
-		accel.y = 0;
-		axis_notify_event(device, time, &accel, &raw);
+		delta.x = wsevent->value / 8;
+		delta.y = 0;
+		v120.x = wsevent->value * 3;
+		v120.y = 0;
+		pointer_notify_axis_wheel(device, time,
+		                          bit(LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL),
+		                          &delta, &v120);
 		break;
 	case WSCONS_EVENT_VSCROLL:
-		memset(&raw, 0, sizeof(raw));
-		accel.x = 0;
-		accel.y = wsevent->value/8;
-		axis_notify_event(device, time, &accel, &raw);
+		delta.x = 0;
+		delta.y = wsevent->value / 8;
+		v120.x = 0;
+		v120.y = wsevent->value * 3;
+		pointer_notify_axis_wheel(device, time,
+		                          bit(LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL),
+		                          &delta, &v120);
 		break;
 
 #ifdef WSCONS_EVENT_SYNC

--- a/src/wscons.c
+++ b/src/wscons.c
@@ -113,7 +113,8 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 {
 	enum libinput_button_state bstate;
 	enum libinput_key_state kstate;
-	struct normalized_coords accel;
+	struct normalized_coords delta = { 0, 0};
+	struct wheel_v120 v120 = { 0.0, 0.0 };
 	struct device_float_coords raw;
 	struct wscons_device *dev = wscons_device(device);
 	uint64_t time;
@@ -167,7 +168,6 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 	case WSCONS_EVENT_MOUSE_DELTA_X:
 	case WSCONS_EVENT_MOUSE_DELTA_Y:
 		memset(&raw, 0, sizeof(raw));
-		memset(&accel, 0, sizeof(accel));
 
 		if (wsevent->type == WSCONS_EVENT_MOUSE_DELTA_X)
 			raw.x = wsevent->value;
@@ -175,30 +175,36 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 			raw.y = -wsevent->value;
 
 		if (dev->pointer.filter) {
-			accel = filter_dispatch(dev->pointer.filter,
+			delta = filter_dispatch(dev->pointer.filter,
 			                        &raw,
 			                	device,
 			                	time);
 		} else {
-			accel.x = raw.x;
-			accel.y = raw.y;
+			delta.x = raw.x;
+			delta.y = raw.y;
 		}
 
-		pointer_notify_motion(device, time, &accel, &raw);
+		pointer_notify_motion(device, time, &delta, &raw);
 		break;
 
 	case WSCONS_EVENT_MOUSE_DELTA_Z:
-		memset(&raw, 0, sizeof(raw));
-		accel.x = 0;
-		accel.y = wsevent->value * 32;
-		axis_notify_event(device, time, &accel, &raw);
+		delta.x = 0;
+		delta.y = wsevent->value * 32;
+		v120.x = 0;
+		v120.y = wsevent->value * 120;
+		pointer_notify_axis_wheel(device, time,
+		                          LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL,
+		                          &delta, &v120);
 		break;
 
 	case WSCONS_EVENT_MOUSE_DELTA_W:
-		memset(&raw, 0, sizeof(raw));
-		accel.x = wsevent->value * 32;
-		accel.y = 0;
-		axis_notify_event(device, time, &accel, &raw);
+		delta.x = wsevent->value * 32;
+		delta.y = 0;
+		v120.x = wsevent->value * 120;
+		v120.y = 0;
+		pointer_notify_axis_wheel(device, time,
+		                          LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL,
+		                          &delta, &v120);
 		break;
 
 	case WSCONS_EVENT_MOUSE_ABSOLUTE_X:
@@ -207,16 +213,22 @@ wscons_process(struct libinput_device *device, struct wscons_event *wsevent)
 		break;
 
 	case WSCONS_EVENT_HSCROLL:
-		memset(&raw, 0, sizeof(raw));
-		accel.x = wsevent->value/8;
-		accel.y = 0;
-		axis_notify_event(device, time, &accel, &raw);
+		delta.x = wsevent->value / 8;
+		delta.y = 0;
+		v120.x = wsevent->value * 3;
+		v120.y = 0;
+		pointer_notify_axis_wheel(device, time,
+		                          LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL,
+		                          &delta, &v120);
 		break;
 	case WSCONS_EVENT_VSCROLL:
-		memset(&raw, 0, sizeof(raw));
-		accel.x = 0;
-		accel.y = wsevent->value/8;
-		axis_notify_event(device, time, &accel, &raw);
+		delta.x = 0;
+		delta.y = wsevent->value / 8;
+		v120.x = 0;
+		v120.y = wsevent->value * 3;
+		pointer_notify_axis_wheel(device, time,
+		                          LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL,
+		                          &delta, &v120);
 		break;
 
 #ifdef WSCONS_EVENT_SYNC


### PR DESCRIPTION
Benefit: 

We don't need to modify ```libinput-private.h``` anymore. This further reduces the diff to upstream code.

How: 

We can reuse an almost unmodified version of upstream's ```pointer_notify_axis_wheel()```, by pushing down the decision on the axis for the event to ```wscons.c```, along with setting the v120 values.

While Here:

* I propose to change the name "accel" to "delta" if only to avoid confusion with the naming convention in upstream code
* The original v120 values I picked for ```HSCROLL``` / ```VSCROLL``` events feel quite aggressive, I propose to tone them down a little